### PR TITLE
ハードコーディングされたdenyIpsの内、サーバー管理者が指定したIPアドレスへのアクセスを許可できる設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 *.o
 *.sh
 *.txt
+/config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=corebuilder /work/hyperproxy /usr/local/bin
+COPY ./config.yaml.sample /etc/hyperproxy/config.yaml
 
 CMD ["hyperproxy"]

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -1,0 +1,1 @@
+whitelist:

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/chai2010/webp => github.com/totegamma/webp v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -88,5 +88,6 @@ google.golang.org/grpc v1.67.1 h1:zWnc1Vrcno+lHZCOofnIMvycFcc0QRGIzm9dhnDX68E=
 google.golang.org/grpc v1.67.1/go.mod h1:1gLDyUQU7CTLJI90u3nXZ9ekeghjeM7pTDZlqFNg2AA=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
〇 ビルド時の設定ファイルとして config.yaml.sample をコンテナイメージ内の /etc/hyperproxy/config.yaml に配置するように修正 
〇 特定のIPアドレスを許可する、ホワイトリスト設定を行える機能を追加
〇 yamlファイルを読み込めるようにするため、go module "gopkg.in/yaml.v3" を追加 
〇 .gitignoreに/config.yamlを追加

ChatGPTの回答を参考にしながら作成しました。
https://chatgpt.com/share/67ac554f-6504-8003-b2c0-5ab4f76eecec

確認をお願い致します。

関連Issue: #4 